### PR TITLE
chore: [ci skip] force LGTM to use Java 11

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    index:
+      java_version: 11


### PR DESCRIPTION
LGTM uses Java 8 by default