### PR TITLE
feat: add module descriptor

### DIFF
--- a/src/main/java/de/eldoria/semvertools/VersionCore.java
+++ b/src/main/java/de/eldoria/semvertools/VersionCore.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @ApiStatus.Internal
-public final class VersionCore implements SemanticVersion {
+final class VersionCore implements SemanticVersion {
   private final int major;
   private final int minor;
   private final int patch;

--- a/src/main/java/de/eldoria/semvertools/VersionParseException.java
+++ b/src/main/java/de/eldoria/semvertools/VersionParseException.java
@@ -4,7 +4,7 @@
  * Copyright (c) 2021 SemVerTools team and contributors
  */
 
-package de.eldoria.semvertools.parser;
+package de.eldoria.semvertools;
 
 public class VersionParseException extends RuntimeException {
 

--- a/src/main/java/de/eldoria/semvertools/parser/SemVerLexer.java
+++ b/src/main/java/de/eldoria/semvertools/parser/SemVerLexer.java
@@ -6,6 +6,7 @@
 
 package de.eldoria.semvertools.parser;
 
+import de.eldoria.semvertools.VersionParseException;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;

--- a/src/main/java/de/eldoria/semvertools/parser/SemVerParser.java
+++ b/src/main/java/de/eldoria/semvertools/parser/SemVerParser.java
@@ -24,14 +24,13 @@ public class SemVerParser {
 
   public SemanticVersion parse() {
     try {
-      VersionCore versionCore = parseVersionCore();
-      return parseOptional(versionCore);
+      return parseOptional(parseVersionCore());
     } catch (VersionParseException e) {
       throw new VersionParseException("Failed to parse version string '" + rawVersionString + "'", e);
     }
   }
 
-  private SemanticVersion parseOptional(VersionCore core) {
+  private SemanticVersion parseOptional(SemanticVersion core) {
     if (this.tokens.isEmpty()) {
       return core;
     }
@@ -46,7 +45,7 @@ public class SemVerParser {
     }
   }
 
-  private SemanticVersion parsePreRelease(VersionCore version) {
+  private SemanticVersion parsePreRelease(SemanticVersion version) {
     List<Identifier> identifiers = new ArrayList<>();
     while (true) {
       parsePreReleaseIdentifier(identifiers);
@@ -97,13 +96,13 @@ public class SemVerParser {
     }
   }
 
-  private VersionCore parseVersionCore() {
+  private SemanticVersion parseVersionCore() {
     int major = parseNumeric();
     expect(TokenType.DOT);
     int minor = parseNumeric();
     expect(TokenType.DOT);
     int patch = parseNumeric();
-    return (VersionCore) SemanticVersion.of(major, minor, patch);
+    return SemanticVersion.of(major, minor, patch);
   }
 
   private Token expect(TokenType type) {

--- a/src/main/java/de/eldoria/semvertools/parser/UnexpectedTokenException.java
+++ b/src/main/java/de/eldoria/semvertools/parser/UnexpectedTokenException.java
@@ -6,6 +6,8 @@
 
 package de.eldoria.semvertools.parser;
 
+import de.eldoria.semvertools.VersionParseException;
+
 import java.util.Arrays;
 
 public class UnexpectedTokenException extends VersionParseException {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2021 SemVerTools team and contributors
+ */
+
+module de.eldoria.semvertools {
+  exports de.eldoria.semvertools;
+
+  requires static org.jetbrains.annotations;
+}

--- a/src/test/java/de/eldoria/semvertools/SemanticVersionTest.java
+++ b/src/test/java/de/eldoria/semvertools/SemanticVersionTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class SemanticVersionTest {
+class SemanticVersionTest {
   @ParameterizedTest
   @ValueSource(strings = {
       // don't allow totally random strings

--- a/src/test/java/de/eldoria/semvertools/SemanticVersionTest.java
+++ b/src/test/java/de/eldoria/semvertools/SemanticVersionTest.java
@@ -6,7 +6,6 @@
 
 package de.eldoria.semvertools;
 
-import de.eldoria.semvertools.parser.VersionParseException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 


### PR DESCRIPTION
I tried to keep the changes to a minimum:
 * add a module descriptor - exports the base package and requires the JetBrains annotations jar (thank god it's modularised as well)
 * make VersionCore package protected - so that only the interfaces from the base package are exposed.